### PR TITLE
Statistics Finland is misspelled in several functions

### DIFF
--- a/R/get_municipalities.R
+++ b/R/get_municipalities.R
@@ -1,7 +1,7 @@
 #' Get Finnish municipality (multi)polygons for different years and/or scales.
 #'
 #' Thin wrapper around Finnish zip code areas provided by
-#' [Statistic Finland](https://www.stat.fi/org/avoindata/paikkatietoaineistot/kuntapohjaiset_tilastointialueet_en.html).
+#' [Statistics Finland](https://www.stat.fi/org/avoindata/paikkatietoaineistot/kuntapohjaiset_tilastointialueet_en.html).
 #'
 #' @param year A numeric for year of the administerative borders. Available are
 #'             2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020 and 2021.

--- a/R/get_population_grid.R
+++ b/R/get_population_grid.R
@@ -1,7 +1,7 @@
 #' Get Finnish Population grid in two different resolutions for years 2010-2019
 #
 #' Thin wrapper around Finnish population grid data provided by
-#' [Statistic Finland](https://www.stat.fi/org/avoindata/paikkatietoaineistot/vaestoruutuaineisto_1km_en.html).
+#' [Statistics Finland](https://www.stat.fi/org/avoindata/paikkatietoaineistot/vaestoruutuaineisto_1km_en.html).
 #'
 #'
 #' @param year A numeric for year of the population grid. Years available 2010-2019.

--- a/R/get_statistical_grid.R
+++ b/R/get_statistical_grid.R
@@ -1,7 +1,7 @@
 #' Get Statistical grid data polygons at two different resolution
 #'
 #' Thin wrapper around Finnish statistical grid data provided by
-#' [Statistic Finland](https://www.stat.fi/org/avoindata/paikkatietoaineistot/vaestoruutuaineisto_1km_en.html).
+#' [Statistics Finland](https://www.stat.fi/org/avoindata/paikkatietoaineistot/vaestoruutuaineisto_1km_en.html).
 #'
 #' @param resolution integer 1 (1km x 1km) or 5 (5km x 5km)
 #' @param auxiliary_data logical Whether to include auxiliary data containing municipality membership data. Default \code{FALSE}

--- a/R/get_zipcodes.R
+++ b/R/get_zipcodes.R
@@ -1,7 +1,7 @@
 #' Get Finnish zip code (multi)polygons for different years.
 #'
 #' Thin wrapper around Finnish zip code areas provided by
-#' [Statistic Finland](https://www.tilastokeskus.fi/tup/karttaaineistot/postinumeroalueet.html).
+#' [Statistics Finland](https://www.tilastokeskus.fi/tup/karttaaineistot/postinumeroalueet.html).
 #'
 #' @param year A numeric for year of the zipcodes. Years available 2015-2021.
 #'


### PR DESCRIPTION
The roxygen2 documentation of all four "get" prefixed functions in geofi have misspelled "Statistics Finland" as "Statistic Finland".