### PR TITLE
Fix issue #46

### DIFF
--- a/R/convert_codes_as_character.R
+++ b/R/convert_codes_as_character.R
@@ -29,11 +29,18 @@ convert_municipality_key_codes <- function(muni_key = geofi::municipality_key) {
                 # "kela_vakuutuspiiri_code", "kela_asumistukialue_code",
                 "hyvinvointialue_code")
 
-  muni_key[, width_3] <- sapply(muni_key[, width_3],
-                                formatC, flag = "0", width = 3)
-  muni_key[, width_2] <- sapply(muni_key[, width_2],
-                                formatC, flag = "0", width = 2)
-  muni_key[, integer_columns] <- sapply(muni_key[, integer_columns], as.integer)
+  muni_key[, names(muni_key) %in% width_3] <- 
+    sapply(
+      X = muni_key[, names(muni_key) %in% width_3],
+      FUN = formatC, flag = "0", width = 3)
+  muni_key[, names(muni_key) %in% width_2] <- 
+    sapply(
+      X = muni_key[, names(muni_key) %in% width_2],
+      FUN = formatC, flag = "0", width = 2)
+  muni_key[, names(muni_key) %in% integer_columns] <- 
+    sapply(
+      X = muni_key[, names(muni_key) %in% integer_columns],
+      FUN = as.integer)
 
   return(muni_key)
 }


### PR DESCRIPTION
Fixes latter part of the issue described in #46 by making subsetting of columns less rigid in case of different column names between different years. What prompted this change was that `sairaanhoitop_code` column is missing from the most recent year 2023, which caused the following error in `convert_municipality_key_codes` function:

```
muns1 <- geofi::get_municipalities(codes_as_character = TRUE, year = 2023)

Error in `muni_key[, width_2]`:
! Can't subset columns that don't exist.
✖ Column `sairaanhoitop_code` doesn't exist.
```